### PR TITLE
Allow nonsymbol keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,12 @@
 PATH
   remote: .
   specs:
-    config_hash (1.1.5)
+    config_hash (1.1.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.1)
     diff-lcs (1.2.5)
-    method_source (0.8.2)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -26,7 +20,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    slop (3.6.0)
 
 PLATFORMS
   ruby
@@ -34,7 +27,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.11)
   config_hash!
-  pry
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.1)
     diff-lcs (1.2.5)
+    method_source (0.8.2)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -20,6 +26,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
@@ -27,6 +34,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.11)
   config_hash!
+  pry
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/config_hash.gemspec
+++ b/config_hash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'config_hash'
-  s.version = '1.1.5'
+  s.version = '1.1.7'
   s.summary = 'a hash built for configurations.'
   s.description = 'A safe hash that can process values and use dot notation.'
   s.authors = ['Zach Lome']
@@ -13,5 +13,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 1.11'
   s.add_development_dependency 'rspec', '~> 3.4'
-  s.add_development_dependency 'pry'
-end
+  end

--- a/config_hash.gemspec
+++ b/config_hash.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 1.11'
   s.add_development_dependency 'rspec', '~> 3.4'
+  s.add_development_dependency 'pry'
 end

--- a/spec/config_hash_spec.rb
+++ b/spec/config_hash_spec.rb
@@ -3,6 +3,11 @@ require 'config_hash'
 RSpec.describe ConfigHash do
   let(:root) do
     {
+      nonstring_keys: {
+        1 => true,
+        true => 1,
+        (0..10) => 'yay',
+      },
       k: [
         {
           v: :bar,
@@ -27,8 +32,9 @@ RSpec.describe ConfigHash do
   let(:config_hash) { ConfigHash.new(root, options) }
   let(:options) { {} }
 
+  subject { config_hash }
+
   describe 'initialization options' do
-    subject { config_hash }
 
     describe ':freeze' do
       it 'defaults to true, and freezes values when true' do
@@ -98,6 +104,12 @@ RSpec.describe ConfigHash do
   end
 
   describe '#[]' do
+    it 'handles non-numeric keys' do
+      expect(subject[:nonstring_keys][1]).to eq true
+      expect(subject[:nonstring_keys][true]).to eq 1
+      expect(subject[:nonstring_keys][(0..10)]).to eq 'yay'
+    end
+
     it 'converts strings to symbols' do
       expect(config_hash['k']).to eq config_hash[:k]
     end


### PR DESCRIPTION
Refactors code to be easier to read and allows for non-symbol/non-string keys.

Also, fixes a bug where `[]` access did not execute processors.

NOTE: this puts ConfigHash on parity with `RecursiveOpenStruct` for read-time optimization, maybe slightly faster. need to find a way to improve it further.