### PR TITLE
Continue fixing enumerable methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    config_hash (1.1.9)
+    config_hash (1.1.10)
 
 GEM
   remote: https://rubygems.org/

--- a/config_hash.gemspec
+++ b/config_hash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'config_hash'
-  s.version = '1.1.9'
+  s.version = '1.1.10'
   s.summary = 'a hash built for configurations.'
   s.description = 'A safe hash that can process values and use dot notation.'
   s.authors = ['Zach Lome']

--- a/lib/config_hash.rb
+++ b/lib/config_hash.rb
@@ -38,7 +38,7 @@ class ConfigHash < Hash
   def [](key)
     key = key.to_sym if key.is_a? String
     if @raise_on_missing && !self.include?(key)
-      raise ArgumentError.new("Missing Key #{key} in #{self.keys}!")
+      raise KeyError.new("key not found: #{key}")
     end
 
     if @lazy_loading && @processors.any?
@@ -105,7 +105,7 @@ class ConfigHash < Hash
 
       self[key] # assignment should return the value
     else
-      raise ArgumentError.new("Missing Key #{method}!") if @raise_on_missing
+      raise KeyError.new("key not found: #{method}!") if @raise_on_missing
       nil
     end
   end


### PR DESCRIPTION
* use 'return' for existing enumerable methods for super call.
* add any, none, all, one, select, methods.
* add a comment.
* remove default/default_proc from initializer, pull from the passed-in hash.
* use KeyError instead of ArgumentError.